### PR TITLE
Fix topology schema reference and warden doc typo

### DIFF
--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:temashop:module:Temashop_DelayedAmqp:etc/topology.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
     <exchange name="magento-delayed" type="x-delayed-message" connection="amqp">
         <binding id="processDelayedMessage"
                  topic="vconnect.delayed.example"

--- a/warden-dev-configurations.md
+++ b/warden-dev-configurations.md
@@ -21,7 +21,7 @@ services:
 5. Restart the Warden environment to apply the changes.
 ```bash
 warden env down
-warden evn stop
+warden env stop
 ```
 
 6. Run the following command to check if the plugin was installed:


### PR DESCRIPTION
## Summary
- correct the schema reference for queue topology
- fix the warden documentation typo

## Testing
- `git status --short`
